### PR TITLE
fix: can't found drm.h in nix

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -21,6 +21,7 @@ wsm_config = static_library(
 		cairo,
 		pango,
 		pangocairo,
+		drm_full,
 	],
 	include_directories:[common_inc, compositor_inc, scene_inc, output_inc, xwl_inc, input_inc, decoration_inc]
 )

--- a/output/meson.build
+++ b/output/meson.build
@@ -7,6 +7,7 @@ wsm_output = static_library(
 	),
 	dependencies: [
 		wlroots,
+		drm_full,
 		server_protos,
 	],
 	include_directories:[common_inc, xwl_inc, compositor_inc, scene_inc, input_inc, config_inc, decoration_inc, shell_inc]

--- a/scene/meson.build
+++ b/scene/meson.build
@@ -23,6 +23,7 @@ wsm_scene = static_library(
 		xpm,
 		jpeg,
 		svg,
+		drm_full,
 	],
 	include_directories:[common_inc, xwl_inc, input_inc, output_inc, compositor_inc, decoration_inc, shell_inc]
 )


### PR DESCRIPTION


```
FAILED: scene/libwsm_scene.a.p/wsm_scene.c.o 
gcc -Iscene/libwsm_scene.a.p -Iscene -I../scene -Icommon -I../common -Ixwl -I../xwl -Iinput -I../input -Ioutput -I../output -Icompositor -I../compositor -Idecoration -I../decoration -Ishell -I../shell -Iprotocols -I/nix/store/9xjfn9aj9vrw7jz3alzbihfhmpb4if62-wlroots-0.18.2/include/wlroots-0.18 -I/nix/store/l0np4qv5260igzj1z5cz4j936i29bn1j-cairo-1.18.2-dev/include/cairo -I/nix/store/wc97xp20zf23vx6rj65ah6knqpqwn9bn-freetype-2.13.3-dev/include/freetype2 -I/nix/store/wc97xp20zf23vx6rj65ah6knqpqwn9bn-freetype-2.13.3-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0 -I/nix/store/rb870mk51kxlxq9crkldzs8n4vwr9sk4-glib-2.82.1/lib/glib-2.0/include -I/nix/store/akxwqfa5h9n4giv2zp04m3v4ngabb18j-pango-1.54.0-dev/include/pango-1.0 -I/nix/store/9w2ars9rx8k0y48pq9fbmqxypmmfga3q-harfbuzz-10.1.0-dev/include/harfbuzz -I/nix/store/2p1gkzwz2lq6vv67579vh4bllw1psqk8-libX11-1.8.10-dev/include -I/nix/store/h6xil473xysi4lp6xr3mnwcfdd9nsr1b-xorgproto-2024.1/include -I/nix/store/5wjwj5zz4nrzg861bhbcwj2k2hm5gkbg-libXpm-3.5.17-dev/include -I/nix/store/6sxnhzr0i1r6bysqm4p9smvq4gjj2s60-libjpeg-turbo-3.0.4-dev/include -I/nix/store/ymwk6q3ac91r731bv5z84bcw84l4m48m-librsvg-2.58.3-dev/include/librsvg-2.0 -I/nix/store/v5flgachjhgvsxqxqi8hnpi19cnbgfwc-gdk-pixbuf-2.42.12-dev/include/gdk-pixbuf-2.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-error=expansion-to-defined -DWLR_USE_UNSTABLE -D_POSIX_C_SOURCE=200809L -Wno-unused-parameter -Wno-unused-result -Wno-missing-braces -Wundef -Wvla -Os '-DSYSCONFDIR="//usr/local/etc"' '-DWSM_VERSION="0.1-dev"' -fmacro-prefix-map=../= -fPIC -MD -MQ scene/libwsm_scene.a.p/wsm_scene.c.o -MF scene/libwsm_scene.a.p/wsm_scene.c.o.d -o scene/libwsm_scene.a.p/wsm_scene.c.o -c ../scene/wsm_scene.c
../scene/wsm_scene.c:17:10: 致命错误：drm_fourcc.h：No such file or directory
   17 | #include <drm_fourcc.h>
      |          ^~~~~~~~~~~~~~
编译中断。
[6/56] Compiling C object scene/libwsm_scene.a.p/node_wsm_text_node.c.o
FAILED: scene/libwsm_scene.a.p/node_wsm_text_node.c.o 
gcc -Iscene/libwsm_scene.a.p -Iscene -I../scene -Icommon -I../common -Ixwl -I../xwl -Iinput -I../input -Ioutput -I../output -Icompositor -I../compositor -Idecoration -I../decoration -Ishell -I../shell -Iprotocols -I/nix/store/9xjfn9aj9vrw7jz3alzbihfhmpb4if62-wlroots-0.18.2/include/wlroots-0.18 -I/nix/store/l0np4qv5260igzj1z5cz4j936i29bn1j-cairo-1.18.2-dev/include/cairo -I/nix/store/wc97xp20zf23vx6rj65ah6knqpqwn9bn-freetype-2.13.3-dev/include/freetype2 -I/nix/store/wc97xp20zf23vx6rj65ah6knqpqwn9bn-freetype-2.13.3-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0 -I/nix/store/rb870mk51kxlxq9crkldzs8n4vwr9sk4-glib-2.82.1/lib/glib-2.0/include -I/nix/store/akxwqfa5h9n4giv2zp04m3v4ngabb18j-pango-1.54.0-dev/include/pango-1.0 -I/nix/store/9w2ars9rx8k0y48pq9fbmqxypmmfga3q-harfbuzz-10.1.0-dev/include/harfbuzz -I/nix/store/2p1gkzwz2lq6vv67579vh4bllw1psqk8-libX11-1.8.10-dev/include -I/nix/store/h6xil473xysi4lp6xr3mnwcfdd9nsr1b-xorgproto-2024.1/include -I/nix/store/5wjwj5zz4nrzg861bhbcwj2k2hm5gkbg-libXpm-3.5.17-dev/include -I/nix/store/6sxnhzr0i1r6bysqm4p9smvq4gjj2s60-libjpeg-turbo-3.0.4-dev/include -I/nix/store/ymwk6q3ac91r731bv5z84bcw84l4m48m-librsvg-2.58.3-dev/include/librsvg-2.0 -I/nix/store/v5flgachjhgvsxqxqi8hnpi19cnbgfwc-gdk-pixbuf-2.42.12-dev/include/gdk-pixbuf-2.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-error=expansion-to-defined -DWLR_USE_UNSTABLE -D_POSIX_C_SOURCE=200809L -Wno-unused-parameter -Wno-unused-result -Wno-missing-braces -Wundef -Wvla -Os '-DSYSCONFDIR="//usr/local/etc"' '-DWSM_VERSION="0.1-dev"' -fmacro-prefix-map=../= -fPIC -MD -MQ scene/libwsm_scene.a.p/node_wsm_text_node.c.o -MF scene/libwsm_scene.a.p/node_wsm_text_node.c.o.d -o scene/libwsm_scene.a.p/node_wsm_text_node.c.o -c ../scene/node/wsm_text_node.c
../scene/node/wsm_text_node.c:10:10: 致命错误：drm_fourcc.h：No such file or directory
   10 | #include <drm_fourcc.h>
      |          ^~~~~~~~~~~~~~
编译中断。
[10/56] Compiling C object scene/libwsm_scene.a.p/node_wsm_image_node.c.o
FAILED: scene/libwsm_scene.a.p/node_wsm_image_node.c.o 
gcc -Iscene/libwsm_scene.a.p -Iscene -I../scene -Icommon -I../common -Ixwl -I../xwl -Iinput -I../input -Ioutput -I../output -Icompositor -I../compositor -Idecoration -I../decoration -Ishell -I../shell -Iprotocols -I/nix/store/9xjfn9aj9vrw7jz3alzbihfhmpb4if62-wlroots-0.18.2/include/wlroots-0.18 -I/nix/store/l0np4qv5260igzj1z5cz4j936i29bn1j-cairo-1.18.2-dev/include/cairo -I/nix/store/wc97xp20zf23vx6rj65ah6knqpqwn9bn-freetype-2.13.3-dev/include/freetype2 -I/nix/store/wc97xp20zf23vx6rj65ah6knqpqwn9bn-freetype-2.13.3-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include -I/nix/store/y8fxzs8srzd6d74a85zbpssjr8wkj9q4-glib-2.82.1-dev/include/glib-2.0 -I/nix/store/rb870mk51kxlxq9crkldzs8n4vwr9sk4-glib-2.82.1/lib/glib-2.0/include -I/nix/store/akxwqfa5h9n4giv2zp04m3v4ngabb18j-pango-1.54.0-dev/include/pango-1.0 -I/nix/store/9w2ars9rx8k0y48pq9fbmqxypmmfga3q-harfbuzz-10.1.0-dev/include/harfbuzz -I/nix/store/2p1gkzwz2lq6vv67579vh4bllw1psqk8-libX11-1.8.10-dev/include -I/nix/store/h6xil473xysi4lp6xr3mnwcfdd9nsr1b-xorgproto-2024.1/include -I/nix/store/5wjwj5zz4nrzg861bhbcwj2k2hm5gkbg-libXpm-3.5.17-dev/include -I/nix/store/6sxnhzr0i1r6bysqm4p9smvq4gjj2s60-libjpeg-turbo-3.0.4-dev/include -I/nix/store/ymwk6q3ac91r731bv5z84bcw84l4m48m-librsvg-2.58.3-dev/include/librsvg-2.0 -I/nix/store/v5flgachjhgvsxqxqi8hnpi19cnbgfwc-gdk-pixbuf-2.42.12-dev/include/gdk-pixbuf-2.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-error=expansion-to-defined -DWLR_USE_UNSTABLE -D_POSIX_C_SOURCE=200809L -Wno-unused-parameter -Wno-unused-result -Wno-missing-braces -Wundef -Wvla -Os '-DSYSCONFDIR="//usr/local/etc"' '-DWSM_VERSION="0.1-dev"' -fmacro-prefix-map=../= -fPIC -MD -MQ scene/libwsm_scene.a.p/node_wsm_image_node.c.o -MF scene/libwsm_scene.a.p/node_wsm_image_node.c.o.d -o scene/libwsm_scene.a.p/node_wsm_image_node.c.o -c ../scene/node/wsm_image_node.c
../scene/node/wsm_image_node.c:16:10: 致命错误：drm_fourcc.h：No such file or directory
   16 | #include <drm_fourcc.h>
      |          ^~~~~~~~~~~~~~
编译中断。
[12/56] Compiling C object output/libwsm_output.a.p/wsm_output.c.o
FAILED: output/libwsm_output.a.p/wsm_output.c.o 
gcc -Ioutput/libwsm_output.a.p -Ioutput -I../output -Icommon -I../common -Ixwl -I../xwl -Icompositor -I../compositor -Iscene -I../scene -Iinput -I../input -Iconfig -I../config -Idecoration -I../decoration -Ishell -I../shell -Iprotocols -I/nix/store/9xjfn9aj9vrw7jz3alzbihfhmpb4if62-wlroots-0.18.2/include/wlroots-0.18 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O0 -g -Wno-error=expansion-to-defined -DWLR_USE_UNSTABLE -D_POSIX_C_SOURCE=200809L -Wno-unused-parameter -Wno-unused-result -Wno-missing-braces -Wundef -Wvla -Os '-DSYSCONFDIR="//usr/local/etc"' '-DWSM_VERSION="0.1-dev"' -fmacro-prefix-map=../= -fPIC -MD -MQ output/libwsm_output.a.p/wsm_output.c.o -MF output/libwsm_output.a.p/wsm_output.c.o.d -o output/libwsm_output.a.p/wsm_output.c.o -c ../output/wsm_output.c
In file included from ../config/wsm_output_config.h:10,
          从 ../output/wsm_output.c:17:
/nix/store/xrg0hqjxy21a8wrfna6s3gnjl9xanhqv-libdrm-2.4.123-dev/include/xf86drmMode.h:43:10: 致命错误：drm.h：No such file or directory
   43 | #include <drm.h>
      |          ^~~~~~~
编译中断。

```



